### PR TITLE
회원가입 기능을 추가합니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.1.1'
+    id 'io.spring.dependency-management' version '1.1.0'
+}
+
+group = 'com'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    sourceCompatibility = '17'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.mindrot:jbcrypt:0.4'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/src/main/java/com/bookbook/controller/UserController.java
+++ b/src/main/java/com/bookbook/controller/UserController.java
@@ -2,15 +2,15 @@ package com.bookbook.controller;
 
 
 import com.bookbook.dto.SignUpRequest;
+import com.bookbook.service.LoginService;
 import com.bookbook.service.UserService;
+import com.bookbook.util.response.CommonResponse;
+import com.bookbook.util.response.ResponseUtil;
 import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import static com.bookbook.util.ResponseEntityConstants.RESPONSE_OK;
 
 @RequestMapping("/api/users")
 @RestController
@@ -23,8 +23,8 @@ public class UserController {
     }
 
     @PostMapping
-    ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
+   public CommonResponse<Long> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
         userService.signUp(signUpRequest);
-        return RESPONSE_OK;
+        return ResponseUtil.success(200, signUpRequest.getId());
     }
 }

--- a/src/main/java/com/bookbook/controller/UserController.java
+++ b/src/main/java/com/bookbook/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.bookbook.controller;
+
+
+import com.bookbook.dto.SignUpRequest;
+import com.bookbook.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.bookbook.util.ResponseEntityConstants.RESPONSE_OK;
+
+@RequestMapping("/api/users")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest signUpRequest) {
+        userService.signUp(signUpRequest);
+        return RESPONSE_OK;
+    }
+}

--- a/src/main/java/com/bookbook/controller/UserController.java
+++ b/src/main/java/com/bookbook/controller/UserController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 @RestController
 public class UserController {
 

--- a/src/main/java/com/bookbook/dto/SignUpRequest.java
+++ b/src/main/java/com/bookbook/dto/SignUpRequest.java
@@ -1,0 +1,30 @@
+package com.bookbook.dto;
+
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class SignUpRequest {
+    private Long id;
+    @NotEmpty
+    private String userId;
+    @NotEmpty
+    private String password;
+
+    private String introduce = "";
+
+    protected SignUpRequest() {}
+
+    private SignUpRequest(String userId, String password, String introduce) {
+        this.userId = userId;
+        this.password = password;
+        this.introduce = introduce;
+    }
+
+    public static SignUpRequest createSignUpRequest(String userId, String password, String introduce) {
+        return new SignUpRequest(userId, password, introduce);
+    }
+}

--- a/src/main/java/com/bookbook/dto/SignUpRequest.java
+++ b/src/main/java/com/bookbook/dto/SignUpRequest.java
@@ -1,11 +1,10 @@
 package com.bookbook.dto;
 
-
+import com.bookbook.util.password.BcryptEncoder;
+import com.bookbook.util.password.Encoder;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
-import lombok.ToString;
 
-@ToString
 @Getter
 public class SignUpRequest {
     private Long id;
@@ -16,15 +15,20 @@ public class SignUpRequest {
 
     private String introduce = "";
 
-    protected SignUpRequest() {}
+    private final Encoder encoder = new BcryptEncoder();
 
-    private SignUpRequest(String userId, String password, String introduce) {
+    public SignUpRequest(String userId, String password, String introduce) {
         this.userId = userId;
-        this.password = password;
         this.introduce = introduce;
+        encryptPassword(password);
     }
 
-    public static SignUpRequest createSignUpRequest(String userId, String password, String introduce) {
-        return new SignUpRequest(userId, password, introduce);
+    public SignUpRequest(String userId, String password) {
+        this.userId = userId;
+        encryptPassword(password);
+    }
+
+    public void encryptPassword(String password) {
+        this.password = encoder.hashPassword(password);
     }
 }

--- a/src/main/java/com/bookbook/dto/SignUpRequest.java
+++ b/src/main/java/com/bookbook/dto/SignUpRequest.java
@@ -15,8 +15,6 @@ public class SignUpRequest {
 
     private String introduce = "";
 
-    private final Encoder encoder = new BcryptEncoder();
-
     private SignUpRequest() {}
 
     public SignUpRequest(String userId, String password, String introduce) {
@@ -30,7 +28,7 @@ public class SignUpRequest {
         encryptPassword(password);
     }
 
-    public void encryptPassword(String password) {
-        this.password = encoder.hashPassword(password);
+    public void updateHashedPassword(final String hashedPassword) {
+        this.password = hashedPassword;
     }
 }

--- a/src/main/java/com/bookbook/dto/SignUpRequest.java
+++ b/src/main/java/com/bookbook/dto/SignUpRequest.java
@@ -17,6 +17,8 @@ public class SignUpRequest {
 
     private final Encoder encoder = new BcryptEncoder();
 
+    private SignUpRequest() {}
+
     public SignUpRequest(String userId, String password, String introduce) {
         this.userId = userId;
         this.introduce = introduce;

--- a/src/main/java/com/bookbook/dto/UserRole.java
+++ b/src/main/java/com/bookbook/dto/UserRole.java
@@ -1,0 +1,6 @@
+package com.bookbook.dto;
+
+public enum UserRole {
+    ADMIN,
+    USER
+}

--- a/src/main/java/com/bookbook/exception/UserIdExistsException.java
+++ b/src/main/java/com/bookbook/exception/UserIdExistsException.java
@@ -1,5 +1,9 @@
 package com.bookbook.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.CONFLICT)
 public class UserIdExistsException extends RuntimeException {
     public UserIdExistsException(String message) {
         super(message);

--- a/src/main/java/com/bookbook/exception/UserIdExistsException.java
+++ b/src/main/java/com/bookbook/exception/UserIdExistsException.java
@@ -1,0 +1,7 @@
+package com.bookbook.exception;
+
+public class UserIdExistsException extends RuntimeException {
+    public UserIdExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bookbook/mapper/UserMapper.java
+++ b/src/main/java/com/bookbook/mapper/UserMapper.java
@@ -3,6 +3,12 @@ package com.bookbook.mapper;
 import com.bookbook.dto.SignUpRequest;
 import org.apache.ibatis.annotations.Mapper;
 
+/*
+* @Mapper 정리
+* - MyBatis의 mappers를 위한 marker interface로 사용한다. -> 특정 매퍼 등록을 위한 어노테이션
+* - 여러 개의 매퍼를 사용하기 위해선 @MapperScan 어노테이션을 사용하고, @Mapper 는 생략할 수도 있다.
+*   - 매퍼 스캔은 basePackages 속성에 지정된 패키지 아래의 모든 인터페이스가 매퍼로 추가된다.
+* */
 @Mapper
 public interface UserMapper {
     Long insertUser(SignUpRequest user);

--- a/src/main/java/com/bookbook/mapper/UserMapper.java
+++ b/src/main/java/com/bookbook/mapper/UserMapper.java
@@ -1,0 +1,10 @@
+package com.bookbook.mapper;
+
+import com.bookbook.dto.SignUpRequest;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserMapper {
+    Long insertUser(SignUpRequest user);
+    boolean selectUserId(String userId);
+}

--- a/src/main/java/com/bookbook/mapper/UserMapper.java
+++ b/src/main/java/com/bookbook/mapper/UserMapper.java
@@ -11,6 +11,6 @@ import org.apache.ibatis.annotations.Mapper;
 * */
 @Mapper
 public interface UserMapper {
-    Long insertUser(SignUpRequest user);
+    void insertUser(SignUpRequest user);
     boolean selectUserId(String userId);
 }

--- a/src/main/java/com/bookbook/service/UserService.java
+++ b/src/main/java/com/bookbook/service/UserService.java
@@ -1,0 +1,39 @@
+package com.bookbook.service;
+
+import com.bookbook.dto.SignUpRequest;
+import com.bookbook.exception.UserIdExistsException;
+import com.bookbook.mapper.UserMapper;
+import com.bookbook.util.password.Encoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserMapper userMapper;
+    private final Encoder encoder;
+
+    public UserService(UserMapper userMapper, Encoder encoder) {
+        this.userMapper = userMapper;
+        this.encoder = encoder;
+    }
+
+    public void signUp(SignUpRequest signUpRequest) {
+        String userId = signUpRequest.getUserId();
+
+        if (checkUniqueUserId(userId)) {
+            throw new UserIdExistsException("이미 가입된 아이디입니다. " + userId);
+        }
+
+        signUpRequest = SignUpRequest.createSignUpRequest(
+                userId,
+                encoder.hashPassword(signUpRequest.getPassword()),
+                signUpRequest.getIntroduce()
+        );
+
+        userMapper.insertUser(signUpRequest);
+    }
+
+    private boolean checkUniqueUserId(String userId) {
+        return userMapper.selectUserId(userId);
+    }
+}

--- a/src/main/java/com/bookbook/service/UserService.java
+++ b/src/main/java/com/bookbook/service/UserService.java
@@ -8,17 +8,24 @@ import org.springframework.stereotype.Service;
 @Service
 public class UserService {
     private final UserMapper userMapper;
+    private final Encoder passwordEncoder;
 
-    public UserService(UserMapper userMapper) {
+    public UserService(UserMapper userMapper, Encoder passwordEncoder) {
         this.userMapper = userMapper;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public void signUp(SignUpRequest signUpRequest) {
         if (checkUniqueUserId(signUpRequest.getUserId())) {
             throw new UserIdExistsException("이미 가입된 아이디입니다. " + signUpRequest.getUserId());
         }
-        signUpRequest.encryptPassword(signUpRequest.getPassword());
+        signUpRequest.updateHashedPassword(encryptPassword(signUpRequest.getPassword()));
         userMapper.insertUser(signUpRequest);
+    }
+
+    public String encryptPassword(final String password) {
+        ;
+        return passwordEncoder.hashPassword(password);
     }
 
     private boolean checkUniqueUserId(String userId) {

--- a/src/main/java/com/bookbook/service/UserService.java
+++ b/src/main/java/com/bookbook/service/UserService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class UserService {
-
     private final UserMapper userMapper;
 
     public UserService(UserMapper userMapper) {
@@ -15,13 +14,10 @@ public class UserService {
     }
 
     public void signUp(SignUpRequest signUpRequest) {
-
         if (checkUniqueUserId(signUpRequest.getUserId())) {
             throw new UserIdExistsException("이미 가입된 아이디입니다. " + signUpRequest.getUserId());
         }
-
         signUpRequest.encryptPassword(signUpRequest.getPassword());
-
         userMapper.insertUser(signUpRequest);
     }
 

--- a/src/main/java/com/bookbook/service/UserService.java
+++ b/src/main/java/com/bookbook/service/UserService.java
@@ -18,17 +18,12 @@ public class UserService {
     }
 
     public void signUp(SignUpRequest signUpRequest) {
-        String userId = signUpRequest.getUserId();
 
-        if (checkUniqueUserId(userId)) {
-            throw new UserIdExistsException("이미 가입된 아이디입니다. " + userId);
+        if (checkUniqueUserId(signUpRequest.getUserId())) {
+            throw new UserIdExistsException("이미 가입된 아이디입니다. " + signUpRequest.getUserId());
         }
 
-        signUpRequest = SignUpRequest.createSignUpRequest(
-                userId,
-                encoder.hashPassword(signUpRequest.getPassword()),
-                signUpRequest.getIntroduce()
-        );
+        signUpRequest.encryptPassword(signUpRequest.getPassword());
 
         userMapper.insertUser(signUpRequest);
     }

--- a/src/main/java/com/bookbook/service/UserService.java
+++ b/src/main/java/com/bookbook/service/UserService.java
@@ -3,18 +3,15 @@ package com.bookbook.service;
 import com.bookbook.dto.SignUpRequest;
 import com.bookbook.exception.UserIdExistsException;
 import com.bookbook.mapper.UserMapper;
-import com.bookbook.util.password.Encoder;
 import org.springframework.stereotype.Service;
 
 @Service
 public class UserService {
 
     private final UserMapper userMapper;
-    private final Encoder encoder;
 
-    public UserService(UserMapper userMapper, Encoder encoder) {
+    public UserService(UserMapper userMapper) {
         this.userMapper = userMapper;
-        this.encoder = encoder;
     }
 
     public void signUp(SignUpRequest signUpRequest) {

--- a/src/main/java/com/bookbook/util/ResponseEntityConstants.java
+++ b/src/main/java/com/bookbook/util/ResponseEntityConstants.java
@@ -1,0 +1,8 @@
+package com.bookbook.util;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityConstants {
+    public static final ResponseEntity<Void> RESPONSE_OK = new ResponseEntity(HttpStatus.OK);
+}

--- a/src/main/java/com/bookbook/util/password/BcryptEncoder.java
+++ b/src/main/java/com/bookbook/util/password/BcryptEncoder.java
@@ -1,0 +1,17 @@
+package com.bookbook.util.password;
+
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BcryptEncoder implements Encoder {
+    @Override
+    public String hashPassword(String rawPassword) {
+        return BCrypt.hashpw(rawPassword, BCrypt.gensalt());
+    }
+
+    @Override
+    public boolean isMatched(String rawPassword, String hashedPassword) {
+        return BCrypt.checkpw(rawPassword, hashedPassword);
+    }
+}

--- a/src/main/java/com/bookbook/util/password/Encoder.java
+++ b/src/main/java/com/bookbook/util/password/Encoder.java
@@ -1,0 +1,7 @@
+package com.bookbook.util.password;
+
+public interface Encoder {
+    String hashPassword(String rawPassword);
+
+    boolean isMatched(String rawPassword, String hashedPassword);
+}

--- a/src/main/java/com/bookbook/util/response/CommonResponse.java
+++ b/src/main/java/com/bookbook/util/response/CommonResponse.java
@@ -1,0 +1,5 @@
+package com.bookbook.util.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record CommonResponse<T>(int code, boolean success, @JsonInclude(JsonInclude.Include.NON_NULL) T result) {}

--- a/src/main/java/com/bookbook/util/response/ResponseUtil.java
+++ b/src/main/java/com/bookbook/util/response/ResponseUtil.java
@@ -1,0 +1,10 @@
+package com.bookbook.util.response;
+
+public class ResponseUtil {
+
+    private ResponseUtil() {}
+
+    public static <T> CommonResponse<T> success(int code, T result) {
+        return new CommonResponse<>(code, true, result);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,18 @@
+mybatis:
+  mapper-locations: classpath:mapper/*.xml
+  type-aliases-package: com.bookbook.dto
+
+debug: false
+management.endpoints.web.exposure.include: "*"
+
+logging:
+  level:
+    com.com.bookbook: debug
+    org.springframework.web.servlet: debug
+
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/bookbook
+    username: wisdom
+    password: asdfasdf33

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -5,10 +5,11 @@
 
 <mapper namespace="com.bookbook.mapper.UserMapper">
     <insert id="insertUser" parameterType="SignUpRequest" useGeneratedKeys="true" keyProperty="id" keyColumn="id">
-        insert into user (user_id, hashed_password, introduce) values(#{userId}, #{password}, #{introduce})
+        INSERT INTO user (user_id, hashed_password, introduce)
+        VALUES (#{userId}, #{password}, #{introduce})
     </insert>
 
     <select id="selectUserId" parameterType="java.lang.String" resultType="boolean">
-        select exists(select 1 from user where user_id = #{userId});
+        SELECT EXISTS (SELECT 1 FROM user WHERE user_id = #{userId});
     </select>
 </mapper>

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.bookbook.mapper.UserMapper">
+    <insert id="insertUser" parameterType="SignUpRequest" useGeneratedKeys="true" keyProperty="id" keyColumn="id">
+        insert into user (user_id, hashed_password, introduce) values(#{userId}, #{password}, #{introduce})
+    </insert>
+
+    <select id="selectUserId" parameterType="java.lang.String" resultType="boolean">
+        select exists(select 1 from user where user_id = #{userId});
+    </select>
+</mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <settings>
+        <setting name="mapUnderscoreToCamelCase" value="true" />
+        <setting name="callSettersOnNulls" value="true"/>
+    </settings>
+</configuration>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
-<configuration>
-    <settings>
-        <setting name="mapUnderscoreToCamelCase" value="true" />
-        <setting name="callSettersOnNulls" value="true"/>
-    </settings>
-</configuration>

--- a/src/test/java/com/bookbook/service/UserServiceTest.java
+++ b/src/test/java/com/bookbook/service/UserServiceTest.java
@@ -7,31 +7,33 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /*
-* @SpringBootTest 정리
-* - 애플리케이션을 테스트하기 위한 많은 기능을 제공한다.
-*   - Spring Boot Test, JUnit, AssertJ, Hamcrest, Mockito ...
-* - ApplicationContext를 쉽게 생성하고 조작할 수 있다.
-* - classes 속성을 통해 빈을 생성할 클래스들을 지정할 수 있고, 지정하지 않으면 애플리케이션 상에 정의된 모든 빈을 생성한다.
-* - @Import 어노테이션을 사용해서 별도로 TestConfiguration을 명시하고 가져다 쓸 수 있다.
-* - @Transactional 어노테이션과 같이 사용하면 rollback 된다. spring-boot-test는 그저 spring-test를 확장한 것이기 때문
-*   - 다만 RANDOM_PORT나 DEFINED_PORT로 테스트를 설정하면 실제 테스트 서버는 별도의 스레드에서 수행되기 때문에 rollback되지 않는다.
-*
-* 언제 사용하나?
-* - 일반적으로 통합테스트 시 사용한다.
-* - business~data layer 와 같이 계층에 걸쳐 테스트할 때 사용하기 좋다.
-* - 참고로 유닛테스트의 경우에는 @WebMvcTest, @DataJpaTest, @MyBatisTest 등을 사용한다
-*
-* 장점
-* - 애플리케이션의 컨텍스트를 전부 셋업하기에 편리하다
-*
-* 단점
-* - 기본적으로 모든 빈을 탐색하고 등록하기 때문에 특정 계층만 테스트할 목적으로 사용하기에는 무겁고 시간이 오래 걸린다.
-* */
+ * @SpringBootTest 정리
+ * - 애플리케이션을 테스트하기 위한 많은 기능을 제공한다.
+ *   - Spring Boot Test, JUnit, AssertJ, Hamcrest, Mockito ...
+ * - ApplicationContext를 쉽게 생성하고 조작할 수 있다.
+ * - classes 속성을 통해 빈을 생성할 클래스들을 지정할 수 있고, 지정하지 않으면 애플리케이션 상에 정의된 모든 빈을 생성한다.
+ * - @Import 어노테이션을 사용해서 별도로 TestConfiguration을 명시하고 가져다 쓸 수 있다.
+ * - @Transactional 어노테이션과 같이 사용하면 rollback 된다. spring-boot-test는 그저 spring-test를 확장한 것이기 때문
+ *   - 다만 RANDOM_PORT나 DEFINED_PORT로 테스트를 설정하면 실제 테스트 서버는 별도의 스레드에서 수행되기 때문에 rollback되지 않는다.
+ *
+ * 언제 사용하나?
+ * - 일반적으로 통합테스트 시 사용한다.
+ * - business~data layer 와 같이 계층에 걸쳐 테스트할 때 사용하기 좋다.
+ * - 참고로 유닛테스트의 경우에는 @WebMvcTest, @DataJpaTest, @MyBatisTest 등을 사용한다
+ *
+ * 장점
+ * - 애플리케이션의 컨텍스트를 전부 셋업하기에 편리하다
+ *
+ * 단점
+ * - 기본적으로 모든 빈을 탐색하고 등록하기 때문에 특정 계층만 테스트할 목적으로 사용하기에는 무겁고 시간이 오래 걸린다.
+ * */
+@Sql("classpath:init.sql")
 @SpringBootTest
 class UserServiceTest {
 

--- a/src/test/java/com/bookbook/service/UserServiceTest.java
+++ b/src/test/java/com/bookbook/service/UserServiceTest.java
@@ -2,7 +2,6 @@ package com.bookbook.service;
 
 import com.bookbook.dto.SignUpRequest;
 import com.bookbook.exception.UserIdExistsException;
-import com.bookbook.util.password.Encoder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,33 +38,41 @@ class UserServiceTest {
     @Autowired
     private UserService userService;
 
-    @Autowired
-    private Encoder passwordEncoder;
-
     SignUpRequest user;
+    SignUpRequest userWithoutIntroduce;
 
     @BeforeEach
     void setUpUser() {
-        String nickname = "wisdom";
-        String password = "pwpwpwpw123";
-        String introduce = "introduce";
-        user = SignUpRequest.createSignUpRequest(
-                nickname,
-                passwordEncoder.hashPassword(password),
-                introduce
+        user = new SignUpRequest(
+                "wisdom",
+                "pwpwpwpw123",
+                "introduce"
+        );
+
+        userWithoutIntroduce = new SignUpRequest(
+                "jihye",
+                "pasdlfkjaslkdf123"
         );
     }
 
-    @DisplayName("유저가 정상적으로 회원가입에 성공합니다")
+    @DisplayName("선택 입력값인 introduce 값이 없어도 유저가 정상적으로 회원가입에 성공합니다")
     @Test
-    void signUp(){
+    void signUpWithoutIntroduce() {
+        userService.signUp(userWithoutIntroduce);
+        assertThat(user.getUserId()).isNotNull();
+    }
+
+    @DisplayName("선택 입력값인 introduce 값이 있는 상황에서 유저가 정상적으로 회원가입에 성공합니다")
+    @Test
+    void signUpWithIntroduce() {
         userService.signUp(user);
         assertThat(user.getUserId()).isNotNull();
     }
 
     @DisplayName("이미 가입된 아이디 입력으로 회원가입에 실패합니다")
     @Test
-    void test(){
+    void signUpWithDuplicatedId() {
+        userService.signUp(user);
         assertThatThrownBy(() -> userService.signUp(user))
                 .isInstanceOf(UserIdExistsException.class)
                 .hasMessageContaining("이미 가입된 아이디입니다.")

--- a/src/test/java/com/bookbook/service/UserServiceTest.java
+++ b/src/test/java/com/bookbook/service/UserServiceTest.java
@@ -12,6 +12,27 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/*
+* @SpringBootTest 정리
+* - 애플리케이션을 테스트하기 위한 많은 기능을 제공한다.
+*   - Spring Boot Test, JUnit, AssertJ, Hamcrest, Mockito ...
+* - ApplicationContext를 쉽게 생성하고 조작할 수 있다.
+* - classes 속성을 통해 빈을 생성할 클래스들을 지정할 수 있고, 지정하지 않으면 애플리케이션 상에 정의된 모든 빈을 생성한다.
+* - @Import 어노테이션을 사용해서 별도로 TestConfiguration을 명시하고 가져다 쓸 수 있다.
+* - @Transactional 어노테이션과 같이 사용하면 rollback 된다. spring-boot-test는 그저 spring-test를 확장한 것이기 때문
+*   - 다만 RANDOM_PORT나 DEFINED_PORT로 테스트를 설정하면 실제 테스트 서버는 별도의 스레드에서 수행되기 때문에 rollback되지 않는다.
+*
+* 언제 사용하나?
+* - 일반적으로 통합테스트 시 사용한다.
+* - business~data layer 와 같이 계층에 걸쳐 테스트할 때 사용하기 좋다.
+* - 참고로 유닛테스트의 경우에는 @WebMvcTest, @DataJpaTest, @MyBatisTest 등을 사용한다
+*
+* 장점
+* - 애플리케이션의 컨텍스트를 전부 셋업하기에 편리하다
+*
+* 단점
+* - 기본적으로 모든 빈을 탐색하고 등록하기 때문에 특정 계층만 테스트할 목적으로 사용하기에는 무겁고 시간이 오래 걸린다.
+* */
 @SpringBootTest
 class UserServiceTest {
 

--- a/src/test/java/com/bookbook/service/UserServiceTest.java
+++ b/src/test/java/com/bookbook/service/UserServiceTest.java
@@ -1,0 +1,54 @@
+package com.bookbook.service;
+
+import com.bookbook.dto.SignUpRequest;
+import com.bookbook.exception.UserIdExistsException;
+import com.bookbook.util.password.Encoder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private Encoder passwordEncoder;
+
+    SignUpRequest user;
+
+    @BeforeEach
+    void setUpUser() {
+        String nickname = "wisdom";
+        String password = "pwpwpwpw123";
+        String introduce = "introduce";
+        user = SignUpRequest.createSignUpRequest(
+                nickname,
+                passwordEncoder.hashPassword(password),
+                introduce
+        );
+    }
+
+    @DisplayName("유저가 정상적으로 회원가입에 성공합니다")
+    @Test
+    void signUp(){
+        userService.signUp(user);
+        assertThat(user.getUserId()).isNotNull();
+    }
+
+    @DisplayName("이미 가입된 아이디 입력으로 회원가입에 실패합니다")
+    @Test
+    void test(){
+        assertThatThrownBy(() -> userService.signUp(user))
+                .isInstanceOf(UserIdExistsException.class)
+                .hasMessageContaining("이미 가입된 아이디입니다.")
+                .hasMessageContaining(user.getUserId())
+        ;
+    }
+}

--- a/src/test/java/com/bookbook/util/password/BcryptEncoderTest.java
+++ b/src/test/java/com/bookbook/util/password/BcryptEncoderTest.java
@@ -1,0 +1,39 @@
+package com.bookbook.util.password;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BcryptEncoderTest {
+
+    private final BcryptEncoder encoder = new BcryptEncoder();
+
+    @DisplayName("BCrypt 에 의해 비밀번호가 정상적으로 해싱 처리된다.")
+    @Test
+    void passwordIsHashedByBCrypt() {
+        String password = "test-password";
+        String hashed = encoder.hashPassword(password);
+
+        assertThat(hashed).hasSize(60);
+        assertTrue(hashed.startsWith("$2a$10$"));
+    }
+
+    @DisplayName("패스워드 입력값이 같으면 해싱 결과값이 동일하다.")
+    @Test
+    void isMatched() {
+        String password = "test-password";
+        assertTrue(encoder.isMatched(password, BCrypt.hashpw(password, BCrypt.gensalt())));
+    }
+
+    @DisplayName("패스워드 입력값이 다르면 해싱 결과값이 동일하지 않다.")
+    @Test
+    void isNotMatchedWithDifferentValue() {
+        String one = "one-password";
+        String another = "another-password";
+        assertFalse(encoder.isMatched(another, BCrypt.hashpw(one, BCrypt.gensalt())));
+    }
+}

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -1,0 +1,2 @@
+DELETE FROM bookbook.user;
+ALTER TABLE bookbook.user AUTO_INCREMENT = 1;


### PR DESCRIPTION
## 작업 목적
- 회원 가입 기능 구현  
## 주요 변경점
- 이전 초기 세팅 커밋에서 빼먹은 `build.gradle` 파일을 추가하고 회원가입 기능 구현까지 필요한 의존성을 추가했습니다.
- POST `/api/user` 회원가입 API를 추가했습니다. 
- 패스워드 암호화는 `jbcrypt` 라이브러리를 사용해서 구현했습니다. 

## 참고
- 현재 회원가입 등록 테스트(UserServiceTest-signUp)의 경우, 아이디가 이미 등록된 경우에 실패하는 테스트입니다. 추후 testcontainer 도입을 통해 해결하면 어떨까 고민하고 있습니다.